### PR TITLE
Define android lint issues file (lint.xml)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+[*.{kt,kts}]
+
+max_line_length=130
+indent_size=4
+continuation_indent_size=4

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -113,11 +113,11 @@ android {
     }
 
     lintOptions {
-        textReport = true             // Write a text report to the console (Useful for CI logs)
-        isExplainIssues = false       // HTML/XML reports are too verbose in console logs
-        isCheckDependencies = false   // Required to get all unused resource from other modules (disabled to speed up linting)
-        isCheckTestSources = true     // Also check test case code for lint issues
-        isCheckReleaseBuilds = false  // If we run a full lint analysis as build part in CI, we can skip redundant checks
+        textReport = true // Write a text report to the console (Useful for CI logs)
+        isExplainIssues = false // HTML/XML reports are too verbose in console logs
+        isCheckDependencies = false // Required to get all unused resource from other modules (disabled to speed up linting)
+        isCheckTestSources = true // Also check test case code for lint issues
+        isCheckReleaseBuilds = false // If we run a full lint analysis as build part in CI, we can skip redundant checks
     }
 }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -111,6 +111,15 @@ android {
             setDimension(ProjectSettings.Flavor.DIMENSION)
         }
     }
+
+    lintOptions {
+        textReport = true             // Write a text report to the console (Useful for CI logs)
+        textOutput("stdout")
+        isExplainIssues = false       // HTML/XML reports are too verbose in console logs
+        isCheckDependencies = false   // Required to get all unused resource from other modules (disabled to speed up linting)
+        isCheckTestSources = true     // Also check test case code for lint issues
+        isCheckReleaseBuilds = false  // If we run a full lint analysis as build part in CI, we can skip redundant checks
+    }
 }
 
 dependencies {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -114,7 +114,6 @@ android {
 
     lintOptions {
         textReport = true             // Write a text report to the console (Useful for CI logs)
-        textOutput("stdout")
         isExplainIssues = false       // HTML/XML reports are too verbose in console logs
         isCheckDependencies = false   // Required to get all unused resource from other modules (disabled to speed up linting)
         isCheckTestSources = true     // Also check test case code for lint issues

--- a/app/lint.xml
+++ b/app/lint.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lint>
+    <issue id="ObsoleteSdkInt" severity="error"/>
+    <issue id="PrivateResource" severity="error"/>
+    <issue id="GradleDynamicVersion" severity="error" />
+    <issue id="CheckResult" severity="error" />
+    <issue id="SimpleDateFormat" severity="error" />  <!-- Use DateFormat correctly with locale -->
+    <issue id="RtlEnabled" severity="error" />
+    <issue id="Registered" severity="error" /> <!-- Class is not registered in the manifest -->
+    <issue id="InnerclassSeparator" severity="error" /> <!-- Inner classes should use $ rather than . -->
+    <issue id="CommitPrefEdits" severity="error" /> <!-- Missing commit() on SharedPreference editor -->
+    <issue id="HardcodedText" severity="error" />
+    <issue id="UnusedAttribute" severity="error" /> <!-- XML attribute unused on older versions -->
+    <issue id="IconLocation" severity="error" /> <!-- Image defined in density-independent drawable folder -->
+    <issue id="GoogleAppIndexingWarning" severity="ignore"/>
+
+    <!-- Version changes are beyond our control, so don't warn. The IDE will still mark these. -->
+    <issue id="GradleDependency" severity="ignore" />
+
+    <!-- Translations are added incrementally -->
+    <issue id="MissingTranslation" severity="ignore" />
+    <issue id="TypographyDashes" severity="ignore" />
+    <issue id="Typos" severity="ignore" />
+
+    <issue id="UnusedIds" severity="ignore"/>  <!-- does not catch uses of view IDs by Kotlin android extensions -->
+
+    <!-- Set Lint check to ignore some warnings in generated sources -->
+    <issue id="RestrictedApi">
+        <ignore path="build" />
+    </issue>
+    <issue id="UnusedResources">
+        <!-- Some dependencies & gradle plugins generate resources that we don't use -->
+        <ignore path="build" />
+    </issue>
+</lint>


### PR DESCRIPTION
- change some Android Lint warnings to errors so they cannot be overlooked
- ignore some warnings in build files and translations
- define gradle lint options to speed up linting, it can be edited in some projects and cases

Mainly inspired by [Google I/O 19 app](https://github.com/google/iosched) and [MichiganLabs](https://michiganlabs.com/2019/08/13/the-lowdown-on-android-lint).